### PR TITLE
Remove unused import

### DIFF
--- a/pydantic_computed/decorator.py
+++ b/pydantic_computed/decorator.py
@@ -1,6 +1,6 @@
 from pydantic import validator, root_validator, create_model
 from typing import Callable, Dict
-from inspect import getargspec, signature
+from inspect import signature
 
 COMPUTED_FIELDS = {}
 


### PR DESCRIPTION
Hello,

I was testing this module but it fails to load with Python 3.11 as `inspect.getargspec` has been removed. This import was not being called, and `tests/test_computed.py` passes with both 3.7 and 3.11.

Cheers!